### PR TITLE
US2 // parts - statusMarker

### DIFF
--- a/components/PartCard/PartCard.styled.js
+++ b/components/PartCard/PartCard.styled.js
@@ -9,9 +9,9 @@ export const PartCardFlexContainer = styled.article`
 `;
 
 export const PartCardCategory = styled.p`
-  border: 1px solid green;
+  border: 1px solid black;
   border-radius: 5px;
-  background-color: green;
+  background-color: var(--color-category);
   padding: 0.5%;
   margin: 0.5%;
 `;

--- a/components/PartCard/index.js
+++ b/components/PartCard/index.js
@@ -14,6 +14,7 @@ export default function PartCard({ part }) {
       </PartCardFlexContainer>
       <PartCardFlexContainer direction={"row"}>
         <PartCardCategory>{part.category}</PartCardCategory>
+        <StatusMarker part={part} />
       </PartCardFlexContainer>
     </PartCardFlexContainer>
   );

--- a/components/PartCard/index.js
+++ b/components/PartCard/index.js
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { PartCardFlexContainer, PartCardCategory } from "./PartCard.styled";
+import StatusMarker from "../StatusMarker";
 
 export default function PartCard({ part }) {
   return (

--- a/components/PartsList/PartsList.styled.js
+++ b/components/PartsList/PartsList.styled.js
@@ -16,8 +16,8 @@ export const StyledHeading = styled.h1`
   top: 0;
   margin-block-start: 0;
   margin-block-end: 0;
-  color: blue;
-  background-color: white;
+  color: var(--color-part);
+  background-color: var(--color-white);
 `;
 
 export const FilterContainer = styled.section`

--- a/components/StatusMarker/StatusMarker.styled.js
+++ b/components/StatusMarker/StatusMarker.styled.js
@@ -1,0 +1,1 @@
+import styled from "styled-components";

--- a/components/StatusMarker/StatusMarker.styled.js
+++ b/components/StatusMarker/StatusMarker.styled.js
@@ -1,3 +1,8 @@
 import styled from "styled-components";
 
-export const StatMarker = styled.p``;
+export const StatMarker = styled.p`
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 0.5%;
+  margin: 0.5%;
+`;

--- a/components/StatusMarker/StatusMarker.styled.js
+++ b/components/StatusMarker/StatusMarker.styled.js
@@ -1,1 +1,3 @@
 import styled from "styled-components";
+
+export const StatMarker = styled.p``;

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -3,9 +3,15 @@ import { StatMarker } from "./StatusMarker.styled";
 export default function StatusMarker({ part }) {
   return (
     <>
-      {part.inAssembler === true ? <p>in Verarbeitung</p> : null}
-      {part.isAssembled === true ? <p>verbaut</p> : <p>unverbaut</p>}
-      {part.isSold === true ? <p>verkauft</p> : null}
+      {part.inAssembler === true ? (
+        <StatMarker>in Verarbeitung</StatMarker>
+      ) : null}
+      {part.isAssembled === true ? (
+        <StatMarker>verbaut</StatMarker>
+      ) : (
+        <p>unverbaut</p>
+      )}
+      {part.isSold === true ? <StatMarker>verkauft</StatMarker> : null}
     </>
   );
 }

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -3,6 +3,7 @@ export default function StatusMarker({ part }) {
     <>
       {part.inAssembler === true ? <p>in Verarbeitung</p> : null}
       {part.isAssembled === true ? <p>verbaut</p> : <p>unverbaut</p>}
+      {part.isSold === true ? <p>verkauft</p> : null}
     </>
   );
 }

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -4,14 +4,24 @@ export default function StatusMarker({ part }) {
   return (
     <>
       {part.inAssembler === true ? (
-        <StatMarker>in Verarbeitung</StatMarker>
+        <StatMarker style={{ backgroundColor: "var(--color-inAssembler)" }}>
+          in Verarbeitung
+        </StatMarker>
       ) : null}
       {part.isAssembled === true ? (
-        <StatMarker>verbaut</StatMarker>
+        <StatMarker style={{ backgroundColor: "var(--color-isAssembled)" }}>
+          verbaut
+        </StatMarker>
       ) : (
-        <p>unverbaut</p>
+        <StatMarker style={{ backgroundColor: "var(--color-isNotAssembled)" }}>
+          unverbaut
+        </StatMarker>
       )}
-      {part.isSold === true ? <StatMarker>verkauft</StatMarker> : null}
+      {part.isSold === true ? (
+        <StatMarker style={{ backgroundColor: "var(--color-isSold)" }}>
+          verkauft
+        </StatMarker>
+      ) : null}
     </>
   );
 }

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -1,0 +1,1 @@
+export default function StatusMarker({ parts }) {}

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -1,3 +1,8 @@
 export default function StatusMarker({ part }) {
-  return <>{part.inAssembler === true ? <p>in Verarbeitung</p> : null}</>;
+  return (
+    <>
+      {part.inAssembler === true ? <p>in Verarbeitung</p> : null}
+      {part.isAssembled === true ? <p>verbaut</p> : <p>unverbaut</p>}
+    </>
+  );
 }

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -1,3 +1,5 @@
+import { StatMarker } from "./StatusMarker.styled";
+
 export default function StatusMarker({ part }) {
   return (
     <>

--- a/components/StatusMarker/index.js
+++ b/components/StatusMarker/index.js
@@ -1,1 +1,3 @@
-export default function StatusMarker({ parts }) {}
+export default function StatusMarker({ part }) {
+  return <>{part.inAssembler === true ? <p>in Verarbeitung</p> : null}</>;
+}

--- a/styles.js
+++ b/styles.js
@@ -7,6 +7,19 @@ export default createGlobalStyle`
     box-sizing: border-box;
   }
 
+  :root {
+    --color-white: #eaeaea;
+    --color-black: #121212;
+    --color-part: blue;
+    --color-item: red;
+    --color-category: green;
+    --color-inAssembler: orange;
+    --color-isNotAssembled: yellow;
+    --color-isAssembled: orangered;
+    --color-isSold: violet;
+    --color-test: pink;
+  }
+
   body {
     margin: 0;
     font-family: system-ui;

--- a/styles.js
+++ b/styles.js
@@ -23,5 +23,6 @@ export default createGlobalStyle`
   body {
     margin: 0;
     font-family: system-ui;
+    background-color: var(--color-white);
   }
 `;


### PR DESCRIPTION
switched position with `categoryMarker` cause this is only one and `statusMarker´ can be more than one.

[US2](https://github.com/matschi3/capstone/issues/2)
[Deployment](https://capstone-7dhp84loa-matschi3.vercel.app/)

Don't worry if the `dummyData` doesn't make real-life-sense:
Some parts have status `sold` + `unused` at the same time.
**This is just for testing all possible solution**