### PR TITLE
us20a // items sort only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ next-env.d.ts
 /lib/items.json
 /lib/categories.json
 /lib/parts_testExport.json
+/lib/capstone.categories_reset.json
+/lib/capstone.items_reset.json
+/lib/capstone.parts_reset.json

--- a/components/ItemCard/index.js
+++ b/components/ItemCard/index.js
@@ -54,7 +54,11 @@ export default function ItemCard({ item }) {
             height={100}
           />
           <PartCardFlexContainer direction="column" justify="flex-start">
-            <PartCardText>{item.dateAssembled}</PartCardText>
+            <PartCardText>
+              {new Date(item.dateAssembled).toLocaleString("de-DE", {
+                medium: "medium",
+              })}
+            </PartCardText>
             <PartCardText>
               {item.totalPurchasingPrice} {item.currency}
             </PartCardText>

--- a/components/PartsList/index.js
+++ b/components/PartsList/index.js
@@ -5,17 +5,13 @@ import StyledFilter from "../StyledFilter/index.js";
 import { FilterContainer } from "../StyledFilter/StyledFilter.styled.js";
 
 export default function PartsList({ parts }) {
-  const [categoryFilter, setCategoryFilter] = useState("alle");
-  const [statusFilter, setStatusFilter] = useState("alle");
-  const [activeCategoryFilter, setActiveCategoryFilter] = useState("alle");
-  const [activeStatusFilter, setActiveStatusFilter] = useState("alle");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+
   // filter the parts array based on the categoryFilter and statusFilter
   const filteredParts = parts.filter((part) => {
-    if (
-      categoryFilter === "alle" ||
-      part.category[0]?.name === categoryFilter
-    ) {
-      if (statusFilter === "alle") {
+    if (categoryFilter === "all" || part.category[0]?.name === categoryFilter) {
+      if (statusFilter === "all") {
         return part;
       } else if (statusFilter === "!isAssembled") {
         return part.isAssembled === false;
@@ -33,87 +29,62 @@ export default function PartsList({ parts }) {
   return (
     <>
       <FilterContainer>
-        {/* render a filterButton for each object in 'sets' with given 'function', 'value to set' and 'name' */}
-        {/* funct2 + value2 for activeFilter-highlighting */}
+        {/* renders a filterButton for each object in 'options' with given 'value'and 'label' */}
         <StyledFilter
-          filters={[
+          options={[
             {
-              functionToSet: setCategoryFilter,
-              valueToSet: "alle",
-              buttonName: "alle",
-              activeFunctionToSet: setActiveCategoryFilter,
-              activeValueToSet: "alle",
+              value: "all",
+              label: "alle",
             },
             {
-              functionToSet: setCategoryFilter,
-              valueToSet: "teller",
-              buttonName: "teller",
-              activeFunctionToSet: setActiveCategoryFilter,
-              activeValueToSet: "teller",
+              value: "teller",
+              label: "teller",
             },
             {
-              functionToSet: setCategoryFilter,
-              valueToSet: "vase",
-              buttonName: "vase",
-              activeFunctionToSet: setActiveCategoryFilter,
-              activeValueToSet: "vase",
+              value: "vase",
+              label: "vase",
             },
             {
-              functionToSet: setCategoryFilter,
-              valueToSet: "schüssel",
-              buttonName: "schüssel",
-              activeFunctionToSet: setActiveCategoryFilter,
-              activeValueToSet: "schüssel",
+              value: "schüssel",
+              label: "schüssel",
             },
             {
-              functionToSet: setCategoryFilter,
-              valueToSet: "figur",
-              buttonName: "figur",
-              activeFunctionToSet: setActiveCategoryFilter,
-              activeValueToSet: "figur",
+              value: "figur",
+              label: "figur",
             },
           ]}
-          activeFilter={activeCategoryFilter}
+          value={categoryFilter}
+          onChange={(newSorting) => {
+            setCategoryFilter(newSorting);
+          }}
         />
         <StyledFilter
-          filters={[
+          options={[
             {
-              functionToSet: setStatusFilter,
-              valueToSet: "alle",
-              buttonName: "alle",
-              activeFunctionToSet: setActiveStatusFilter,
-              activeValueToSet: "alle",
+              value: "all",
+              label: "alle",
             },
             {
-              functionToSet: setStatusFilter,
-              valueToSet: "!isAssembled",
-              buttonName: "unverbaut",
-              activeFunctionToSet: setActiveStatusFilter,
-              activeValueToSet: "!isAssembled",
+              value: "!isAssembled",
+              label: "unverbaut",
             },
             {
-              functionToSet: setStatusFilter,
-              valueToSet: "inAssembler",
-              buttonName: "in Verarbeitung",
-              activeFunctionToSet: setActiveStatusFilter,
-              activeValueToSet: "inAssembler",
+              value: "inAssembler",
+              label: "in Verarbeitung",
             },
             {
-              functionToSet: setStatusFilter,
-              valueToSet: "isAssembled",
-              buttonName: "verbaut",
-              activeFunctionToSet: setActiveStatusFilter,
-              activeValueToSet: "isAssembled",
+              value: "isAssembled",
+              label: "verbaut",
             },
             {
-              functionToSet: setStatusFilter,
-              valueToSet: "isSold",
-              buttonName: "verkauft",
-              activeFunctionToSet: setActiveStatusFilter,
-              activeValueToSet: "isSold",
+              value: "isSold",
+              label: "verkauft",
             },
           ]}
-          activeFilter={activeStatusFilter}
+          value={statusFilter}
+          onChange={(newSorting) => {
+            setStatusFilter(newSorting);
+          }}
         />
       </FilterContainer>
       <PartsListContainer>

--- a/components/StyledFilter/index.js
+++ b/components/StyledFilter/index.js
@@ -1,19 +1,18 @@
 import { FilterButtonContainer, FilterButton } from "./StyledFilter.styled";
 
-export default function StyledFilter({ filters, activeFilter }) {
-  // Mapping over given "filters" array of objects and rendering a FilterButton component for each element with the given "functionToSet", "valueToSet" and "buttonName"
+export default function StyledFilter({ options, value, onChange }) {
+  // Mapping over given "filters" array of objects and rendering a FilterButton component for each element with the given 'value' and 'label'
   return (
     <FilterButtonContainer>
-      {filters.map((filter) => (
+      {options.map((option) => (
         <FilterButton
-          key={filter.buttonName}
+          key={option.value}
           onClick={() => {
-            filter.functionToSet(filter.valueToSet);
-            filter.activeFunctionToSet(filter.activeValueToSet);
+            onChange(option.value);
           }}
-          isActiveFilter={filter.activeValueToSet === activeFilter}
+          isActiveFilter={value === option.value}
         >
-          {filter.buttonName}
+          {option.label}
         </FilterButton>
       ))}
     </FilterButtonContainer>

--- a/pages/create-item.js
+++ b/pages/create-item.js
@@ -23,15 +23,11 @@ export default function CreateItemPage() {
     ) {
       alert("entferne bitte alle bereits verbauten oder verkauften Teile");
     } else {
-      // get today's date for new item and assembled parts as 'dd.mm.yyyy'
-      const todayDate = new Date().toLocaleDateString("de-DE", {
-        dateStyle: "medium",
-      });
       // create new item from inAssemblerParts
       const newItem = {
         uuid: uuidv4(),
         name: "",
-        dateAssembled: todayDate,
+        dateAssembled: new Date(),
         parts: inAssemblerParts.map((part) => part._id),
         totalPurchasingPrice: inAssemblerParts.reduce(
           (sum, part) => sum + part.purchasingPrice,
@@ -57,7 +53,7 @@ export default function CreateItemPage() {
             ...part,
             inAssembler: false,
             isAssembled: true,
-            dateAssembled: todayDate,
+            dateAssembled: newItem.dateAssembled,
           };
           const response = fetch(`/api/parts/${part._id}`, {
             method: "PUT",

--- a/pages/items.js
+++ b/pages/items.js
@@ -7,8 +7,7 @@ import StyledFilter from "../components/StyledFilter/index.js";
 import { FilterContainer } from "../components/StyledFilter/StyledFilter.styled.js";
 
 export default function ItemsPage() {
-  const [sorting, setSorting] = useState("verbaut(neueste)");
-  const [activeSorting, setActiveSorting] = useState("verbaut(neueste)");
+  const [sorting, setSorting] = useState("dateAssembled(DESC)");
 
   const { data: items, isLoading, error } = useSWR("/api/items");
   if (isLoading) {
@@ -22,12 +21,12 @@ export default function ItemsPage() {
   }
 
   const sortedItems = items.slice().sort((a, b) => {
-    if (sorting === "verbaut(neueste)") {
+    if (sorting === "dateAssembled(DESC)") {
       return new Date(b.dateAssembled) - new Date(a.dateAssembled);
-    } else if (sorting === "verbaut(älteste)") {
+    } else if (sorting === "dateAssembled(ASC)") {
       return new Date(a.dateAssembled) - new Date(b.dateAssembled);
       // in this case, there are items with NO dateSold set -> sort them to the end
-    } else if (sorting === "verkauft(neueste)") {
+    } else if (sorting === "dateSold(DESC)") {
       if (a.dateSold && b.dateSold) {
         return new Date(b.dateSold) - new Date(a.dateSold);
       } else if (a.dateSold && !b.dateSold) {
@@ -37,8 +36,8 @@ export default function ItemsPage() {
       } else {
         return new Date(b.dateAssembled) - new Date(a.dateAssembled);
       }
-      // in this case, there are items with NO dateSold set -> sort them to the end
-    } else if (sorting === "verkauft(älteste)") {
+      // in this case, there are items with NO dateSold set, too -> sort them to the end
+    } else if (sorting === "dateSold(ASC)") {
       if (a.dateSold && b.dateSold) {
         return new Date(a.dateSold) - new Date(b.dateSold);
       } else if (a.dateSold && !b.dateSold) {
@@ -56,40 +55,30 @@ export default function ItemsPage() {
     <>
       <StyledHeader title="ITEMS" color="var(--color-item)" />
       <FilterContainer>
-        {/* render a filterButton for each object in 'sets' with given 'function', 'value to set' and 'name' */}
-        {/* funct2 + value2 for activeFilter-highlighting */}
+        {/* render a filterButton for each object in 'options' with given 'value' and 'label' */}
         <StyledFilter
-          filters={[
+          options={[
             {
-              functionToSet: setSorting,
-              valueToSet: "verbaut(neueste)",
-              buttonName: "verbaut (neueste)",
-              activeFunctionToSet: setActiveSorting,
-              activeValueToSet: "verbaut(neueste)",
+              value: "dateAssembled(DESC)",
+              label: "verbaut (neueste)",
             },
             {
-              functionToSet: setSorting,
-              valueToSet: "verbaut(älteste)",
-              buttonName: "verbaut (älteste)",
-              activeFunctionToSet: setActiveSorting,
-              activeValueToSet: "verbaut(älteste)",
+              value: "dateAssembled(ASC)",
+              label: "verbaut (älteste)",
             },
             {
-              functionToSet: setSorting,
-              valueToSet: "verkauft(neueste)",
-              buttonName: "verkauft (neueste)",
-              activeFunctionToSet: setActiveSorting,
-              activeValueToSet: "verkauft(neueste)",
+              value: "dateSold(DESC)",
+              label: "verkauft (neueste)",
             },
             {
-              functionToSet: setSorting,
-              valueToSet: "verkauft(älteste)",
-              buttonName: "verkauft (älteste)",
-              activeFunctionToSet: setActiveSorting,
-              activeValueToSet: "verkauft(älteste)",
+              value: "dateSold(ASC)",
+              label: "verkauft (älteste)",
             },
           ]}
-          activeFilter={activeSorting}
+          value={sorting}
+          onChange={(newSorting) => {
+            setSorting(newSorting);
+          }}
         />
       </FilterContainer>
       {sortedItems.map((item) => (

--- a/pages/items.js
+++ b/pages/items.js
@@ -5,6 +5,8 @@ import useSWR from "swr";
 import { useState } from "react";
 
 export default function ItemsPage() {
+  const [sorting, setSorting] = useState("verbaut(neueste)");
+
   const { data: items, isLoading, error } = useSWR("/api/items");
   if (isLoading) {
     return <h1>lädt Items...</h1>;

--- a/pages/items.js
+++ b/pages/items.js
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 export default function ItemsPage() {
   const [sorting, setSorting] = useState("verbaut(neueste)");
+  const [activeSorting, setActiveSorting] = useState("verbaut(neueste)");
 
   const { data: items, isLoading, error } = useSWR("/api/items");
   if (isLoading) {

--- a/pages/items.js
+++ b/pages/items.js
@@ -21,7 +21,7 @@ export default function ItemsPage() {
     return <h1>error! fehlerhafte Daten.</h1>;
   }
 
-  const sortedItems = items.sort((a, b) => {
+  const sortedItems = items.slice().sort((a, b) => {
     if (sorting === "verbaut(neueste)") {
       return new Date(b.dateAssembled) - new Date(a.dateAssembled);
     } else if (sorting === "verbaut(älteste)") {

--- a/pages/items.js
+++ b/pages/items.js
@@ -24,6 +24,43 @@ export default function ItemsPage() {
   return (
     <>
       <StyledHeader title="ITEMS" color="var(--color-item)" />
+      <FilterContainer>
+        {/* render a filterButton for each object in 'sets' with given 'function', 'value to set' and 'name' */}
+        {/* funct2 + value2 for activeFilter-highlighting */}
+        <StyledFilter
+          filters={[
+            {
+              functionToSet: setSorting,
+              valueToSet: "verbaut(neueste)",
+              buttonName: "verbaut (neueste)",
+              activeFunctionToSet: setActiveSorting,
+              activeValueToSet: "verbaut(neueste)",
+            },
+            {
+              functionToSet: setSorting,
+              valueToSet: "verbaut(älteste)",
+              buttonName: "verbaut (älteste)",
+              activeFunctionToSet: setActiveSorting,
+              activeValueToSet: "verbaut(älteste)",
+            },
+            {
+              functionToSet: setSorting,
+              valueToSet: "verkauft(neueste)",
+              buttonName: "verkauft (neueste)",
+              activeFunctionToSet: setActiveSorting,
+              activeValueToSet: "verkauft(neueste)",
+            },
+            {
+              functionToSet: setSorting,
+              valueToSet: "verkauft(älteste)",
+              buttonName: "verkauft (älteste)",
+              activeFunctionToSet: setActiveSorting,
+              activeValueToSet: "verkauft(älteste)",
+            },
+          ]}
+          activeFilter={activeSorting}
+        />
+      </FilterContainer>
       {items.map((item) => (
         <ItemCard key={item._id} item={item} />
       ))}

--- a/pages/items.js
+++ b/pages/items.js
@@ -27,10 +27,33 @@ export default function ItemsPage() {
     } else if (sorting === "verbaut(älteste)") {
       return new Date(a.dateAssembled) - new Date(b.dateAssembled);
     } else if (sorting === "verkauft(neueste)") {
-      return new Date(b.dateSold) - new Date(a.dateSold);
+      if (a.dateSold && b.dateSold) {
+        return new Date(b.dateSold) - new Date(a.dateSold);
+      } else if (a.dateSold && !b.dateSold) {
+        return -1;
+      } else if (!a.dateSold && b.dateSold) {
+        return 1;
+      } else {
+        return new Date(b.dateAssembled) - new Date(a.dateAssembled);
+      }
     } else if (sorting === "verkauft(älteste)") {
-      return new Date(a.dateSold) - new Date(b.dateSold);
+      if (a.dateSold && b.dateSold) {
+        return new Date(a.dateSold) - new Date(b.dateSold);
+      } else if (a.dateSold && !b.dateSold) {
+        return -1;
+      } else if (!a.dateSold && b.dateSold) {
+        return 1;
+      } else {
+        return new Date(a.dateAssembled) - new Date(b.dateAssembled);
+      }
     }
+    return 0;
+  });
+
+  sortedItems.map((item) => {
+    console.log(item._id);
+    console.log(item.dateAssembled);
+    console.log(item.dateSold);
   });
 
   return (

--- a/pages/items.js
+++ b/pages/items.js
@@ -3,8 +3,8 @@ import ItemCard from "../components/ItemCard/index.js";
 import StyledFooter from "../components/StyledFooter/index.js";
 import useSWR from "swr";
 import { useState } from "react";
-import StyledFilter from "../StyledFilter/index.js";
-import { FilterContainer } from "../StyledFilter/StyledFilter.styled.js";
+import StyledFilter from "../components/StyledFilter/index.js";
+import { FilterContainer } from "../components/StyledFilter/StyledFilter.styled.js";
 
 export default function ItemsPage() {
   const [sorting, setSorting] = useState("verbaut(neueste)");

--- a/pages/items.js
+++ b/pages/items.js
@@ -21,6 +21,18 @@ export default function ItemsPage() {
     return <h1>error! fehlerhafte Daten.</h1>;
   }
 
+  const sortedItems = items.sort((a, b) => {
+    if (sorting === "verbaut(neueste)") {
+      return new Date(b.dateAssembled) - new Date(a.dateAssembled);
+    } else if (sorting === "verbaut(älteste)") {
+      return new Date(a.dateAssembled) - new Date(b.dateAssembled);
+    } else if (sorting === "verkauft(neueste)") {
+      return new Date(b.dateSold) - new Date(a.dateSold);
+    } else if (sorting === "verkauft(älteste)") {
+      return new Date(a.dateSold) - new Date(b.dateSold);
+    }
+  });
+
   return (
     <>
       <StyledHeader title="ITEMS" color="var(--color-item)" />
@@ -61,7 +73,7 @@ export default function ItemsPage() {
           activeFilter={activeSorting}
         />
       </FilterContainer>
-      {items.map((item) => (
+      {sortedItems.map((item) => (
         <ItemCard key={item._id} item={item} />
       ))}
       <StyledFooter />

--- a/pages/items.js
+++ b/pages/items.js
@@ -26,6 +26,7 @@ export default function ItemsPage() {
       return new Date(b.dateAssembled) - new Date(a.dateAssembled);
     } else if (sorting === "verbaut(älteste)") {
       return new Date(a.dateAssembled) - new Date(b.dateAssembled);
+      // in this case, there are items with NO dateSold set -> sort them to the end
     } else if (sorting === "verkauft(neueste)") {
       if (a.dateSold && b.dateSold) {
         return new Date(b.dateSold) - new Date(a.dateSold);
@@ -36,6 +37,7 @@ export default function ItemsPage() {
       } else {
         return new Date(b.dateAssembled) - new Date(a.dateAssembled);
       }
+      // in this case, there are items with NO dateSold set -> sort them to the end
     } else if (sorting === "verkauft(älteste)") {
       if (a.dateSold && b.dateSold) {
         return new Date(a.dateSold) - new Date(b.dateSold);

--- a/pages/items.js
+++ b/pages/items.js
@@ -52,12 +52,6 @@ export default function ItemsPage() {
     return 0;
   });
 
-  sortedItems.map((item) => {
-    console.log(item._id);
-    console.log(item.dateAssembled);
-    console.log(item.dateSold);
-  });
-
   return (
     <>
       <StyledHeader title="ITEMS" color="var(--color-item)" />

--- a/pages/items.js
+++ b/pages/items.js
@@ -2,6 +2,7 @@ import StyledHeader from "../components/StyledHeader/index.js";
 import ItemCard from "../components/ItemCard/index.js";
 import StyledFooter from "../components/StyledFooter/index.js";
 import useSWR from "swr";
+import { useState } from "react";
 
 export default function ItemsPage() {
   const { data: items, isLoading, error } = useSWR("/api/items");

--- a/pages/items.js
+++ b/pages/items.js
@@ -3,6 +3,8 @@ import ItemCard from "../components/ItemCard/index.js";
 import StyledFooter from "../components/StyledFooter/index.js";
 import useSWR from "swr";
 import { useState } from "react";
+import StyledFilter from "../StyledFilter/index.js";
+import { FilterContainer } from "../StyledFilter/StyledFilter.styled.js";
 
 export default function ItemsPage() {
   const [sorting, setSorting] = useState("verbaut(neueste)");


### PR DESCRIPTION
Sort `items` for its date `assembled` or `sold`.
`dateAssembled` is the date displayed on top of each `itemCard`.
`dateSold` is not displayed so you gotta believe, but its working as like the `dateAssembled`  ;)
You can see if there is no `VK(ist)` and `Gewinn(ist)` the item is not sold and has no `dateSold` set so it should get displayed at the end when sorting for `dateAssembled`

[US20a](https://github.com/matschi3/capstone/issues/42)
[Deployment](https://capstone-apr7hjslu-matschi3.vercel.app/items)